### PR TITLE
Potential fix for code scanning alert no. 92: Uncontrolled data used in path expression

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -225,7 +225,11 @@ const uploadImage = async (req, res, fieldName) => {
   } catch (error) {
     // If there's an error, delete the uploaded file
     if (req.file && req.file.path) {
-      fs.unlinkSync(req.file.path);
+      const uploadDir = path.resolve(process.env.UPLOAD_DIR);
+      const filePath = path.resolve(req.file.path);
+      if (filePath.startsWith(uploadDir)) {
+        fs.unlinkSync(filePath);
+      }
     }
 
     return res.status(500).json({


### PR DESCRIPTION
Potential fix for [https://github.com/mdawoud27/job-search-app/security/code-scanning/92](https://github.com/mdawoud27/job-search-app/security/code-scanning/92)

To fix the problem, we need to ensure that the file path derived from `req.file.path` is validated before it is used. We can achieve this by normalizing the path and ensuring it is within a predefined safe directory. This involves:
1. Normalizing the path using `path.resolve` to remove any ".." segments.
2. Checking that the normalized path starts with the predefined upload directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
