### PR TITLE
Potential fix for code scanning alert no. 84: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -249,6 +249,9 @@ export const googleOAuthLogin = async (req, res) => {
 export const sendForgetPasswordOTP = async (req, res, next) => {
   try {
     const { email } = req.body;
+    if (typeof email !== 'string') {
+      return res.status(400).json({ message: 'Invalid email format' });
+    }
 
     const user = await User.findOne({ email, provider: 'system' });
     if (!user) {


### PR DESCRIPTION
Potential fix for [https://github.com/mdawoud27/job-search-app/security/code-scanning/84](https://github.com/mdawoud27/job-search-app/security/code-scanning/84)

To fix the problem, we need to ensure that the `email` field is a literal value and not a query object before using it in the MongoDB query. This can be achieved by validating the `email` field to ensure it is a string. If it is not a string, we should return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
