### PR TITLE
Potential fix for code scanning alert no. 91: Uncontrolled data used in path expression

### DIFF
--- a/src/controllers/company.controller.js
+++ b/src/controllers/company.controller.js
@@ -344,7 +344,12 @@ const uploadCompanyImage = async (req, res, fieldName) => {
   } catch (error) {
     // If there's an error, delete the uploaded file
     if (req.file && req.file.path) {
-      fs.unlinkSync(req.file.path);
+      const normalizedPath = path.resolve(req.file.path);
+      if (normalizedPath.startsWith(path.resolve(process.env.UPLOAD_DIR))) {
+        fs.unlinkSync(normalizedPath);
+      } else {
+        console.error('Attempted to delete a file outside the upload directory:', normalizedPath);
+      }
     }
 
     return res.status(500).json({ error: error.message });


### PR DESCRIPTION
Potential fix for [https://github.com/mdawoud27/job-search-app/security/code-scanning/91](https://github.com/mdawoud27/job-search-app/security/code-scanning/91)

To fix the problem, we need to ensure that the file path derived from `req.file.path` is validated and sanitized before being used. We can achieve this by normalizing the path and ensuring it is contained within a predefined safe directory. This will prevent path traversal attacks and unauthorized file deletions.

1. Normalize the file path using `path.resolve` to remove any ".." segments.
2. Ensure the normalized path starts with the predefined safe directory (e.g., `process.env.UPLOAD_DIR`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
